### PR TITLE
Cache overridePath with attribute added

### DIFF
--- a/Amorphie.Core.Cache/Attributes/DistributedCacheAttribute.cs
+++ b/Amorphie.Core.Cache/Attributes/DistributedCacheAttribute.cs
@@ -3,15 +3,13 @@ namespace Amorphie.Core.Cache.Redis;
 public class DistributedCacheAttribute : Attribute
 {
     public int TimeToLiveMinutes { get; set; }
-    public List<string> HeadersToDiffer { get; set; }
-    public DistributedCacheAttribute(int timeToLiveMinutes)
-    {
-        HeadersToDiffer = new List<string>();
-        TimeToLiveMinutes = timeToLiveMinutes;
-    }
-    public DistributedCacheAttribute(int timeToLiveMinutes, string[] headersToDiffer)
+    public List<string> HeadersToDiffer { get; set; } = new List<string>();
+    public string? OverridePathWith { get; set; }
+
+    public DistributedCacheAttribute(int timeToLiveMinutes, string[]? headersToDiffer = null, string? overridePathWith = null)
     {
         TimeToLiveMinutes = timeToLiveMinutes;
-        HeadersToDiffer = headersToDiffer.ToList();
+        OverridePathWith = overridePathWith;
+        HeadersToDiffer ??= headersToDiffer.ToList();
     }
 }


### PR DESCRIPTION
Now you can override cache key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Enhanced Caching Customization:** Users can now optionally specify a custom override path, allowing greater control over how cache keys are generated.
  - **Improved Header Handling:** The caching mechanism now dynamically accounts for header differences, offering more flexible caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->